### PR TITLE
Fix table header label

### DIFF
--- a/src/components/page/prompt/PromptList.jsx
+++ b/src/components/page/prompt/PromptList.jsx
@@ -46,7 +46,7 @@ function PromptList() {
                             Objetivo
                         </th>
                         <th scope="col" className="px-3 sm:px-6 py-2 sm:py-3 text-left text-xs sm:text-sm font-medium text-gray-500 uppercase tracking-wider w-2/3">
-                            Descrição
+                            Descripción
                         </th>
                         <th scope="col" className="relative px-3 sm:px-6 py-2 sm:py-3 w-10">
                         </th>


### PR DESCRIPTION
## Summary
- update the Portuguese table header to its Spanish spelling "Descripción"

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840f4aca0648331a06420733cb57b15